### PR TITLE
add creality_e2p24s4 board

### DIFF
--- a/src/config/board.h
+++ b/src/config/board.h
@@ -3,6 +3,8 @@
 
 #if IS_BOARD(VOXELAB_V101)
   #include "boards/voxelab_v101.h"
+#elif IS_BOARD(CREALITY_E2P24S4)
+  #include "boards/creality_e2p24s4.h"
 #else
   #error "Unknown board"
 #endif

--- a/src/config/boards.h
+++ b/src/config/boards.h
@@ -1,6 +1,6 @@
 #pragma once
 
 #define BOARD_VOXELAB_V101 1000
-
+#define BOARD_CREALITY_E2P24S4 2000
 
 #define IS_BOARD(board) (BOARD == BOARD_##board)

--- a/src/config/boards/creality_e2p24s4.h
+++ b/src/config/boards/creality_e2p24s4.h
@@ -1,0 +1,35 @@
+//
+// Creality Ender 2 Pro v2.4.S4_170 (HC32f460KCTA)
+//
+#pragma once
+#include "../../config_options.h"
+
+// Ender 2 Pro uses DOGM screen, so disable screen
+#ifndef SCREEN_DRIVER
+  #define SCREEN_DRIVER SCREEN_NONE
+#endif
+
+// Ender 2 Pro uses the HC32F460C variant
+#ifndef CHIPID_VARIANT_OVERRIDE
+  #define CHIPID_VARIANT_OVERRIDE chipid::variant::HC32F460C
+#endif
+
+// Serial ports
+#ifndef HOST_SERIAL_TX
+  #define HOST_SERIAL_TX gpio::PA8
+#endif
+
+// Beeper pin
+#ifndef BEEPER_PIN
+  #define BEEPER_PIN gpio::PC6
+#endif
+
+// SDIO pins
+#ifndef SDIO_PINS
+  #define SDIO_PINS { gpio::PC12, gpio::PD2, gpio::PA10, gpio::PC8, gpio::PC9, gpio::PC10, gpio::PC11 }
+#endif
+
+// Ender 2 Pro bootloader disables JTDO, JTDI, and NJTRST
+#ifndef COMPAT_DISABLE_DEBUG_PORT
+  #define COMPAT_DISABLE_DEBUG_PORT (COMPAT_DBG_JTDO | COMPAT_DBG_JTDI | COMPAT_DBG_NJTRST)
+#endif


### PR DESCRIPTION
based on marlin pins @ https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/Marlin/src/pins/hc32f4/pins_CREALITY_ENDER2P_V24S4.h